### PR TITLE
18: implemennt service and dayoftheweek entities

### DIFF
--- a/.claude/agent-memory/code-retrospective/MEMORY.md
+++ b/.claude/agent-memory/code-retrospective/MEMORY.md
@@ -18,6 +18,9 @@
 - Missing `.env` file on fresh checkout — `.env.example` exists but no setup script copies it
 - Migrations must be run manually before e2e tests; no `pretest` script enforces this
 - The `test:e2e` root script does not set up prerequisites (env, migrations, browser install)
+- Dynamic SQL builders using `Record<string, ...>` keys for column names — always check for allowlist; found in PR #16 `applyUserUpdate`
+- `ApiErrorCode` constants in Flutter client lag behind backend `ErrorCode` additions — `AUTH_USER_EXISTS` missing in PR #16
+- `ON DELETE CASCADE` FKs exist on `refresh_tokens` and `password_resets` (confirmed in migrations 003, 004) and `PRAGMA foreign_keys = ON` is set in `connection.ts` — manual child-row deletes in transactions are redundant
 
 ### Onboarding Gaps
 - No `setup.sh` or `bun run setup` script at root level

--- a/.vscode/bruno-collections/Service/create-service-forbidden.bru
+++ b/.vscode/bruno-collections/Service/create-service-forbidden.bru
@@ -1,0 +1,59 @@
+meta {
+  name: Create Service Forbidden
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{base_url}}/services
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Should Fail",
+    "description": "Non-admin should not be able to create"
+  }
+}
+
+script:pre-request {
+  // Log in as a volunteer (non-admin) user
+  const baseUrl = bru.getEnvVar("base_url");
+  const password = bru.getEnvVar("test_password");
+
+  const loginRes = await fetch(baseUrl + "/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "volunteer-test@example.com",
+      password: password
+    })
+  });
+
+  if (loginRes.ok) {
+    const loginBody = await loginRes.json();
+    req.setHeader("Authorization", "Bearer " + loginBody.data.accessToken);
+  }
+}
+
+tests {
+  test("should return 403", function() {
+    expect(res.getStatus()).to.equal(403);
+  });
+
+  test("should have FORBIDDEN error", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.false;
+    expect(body.error.code).to.equal('FORBIDDEN');
+  });
+}
+
+docs {
+  # Create Service Forbidden
+
+  Verifies that a non-admin user cannot create services.
+
+  **Prerequisites:**
+  - Run `bun run seed:test` to create the volunteer-test@example.com user
+}

--- a/.vscode/bruno-collections/Service/create-service.bru
+++ b/.vscode/bruno-collections/Service/create-service.bru
@@ -1,0 +1,59 @@
+meta {
+  name: Create Service
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{base_url}}/services
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{admin_token}}
+}
+
+body:json {
+  {
+    "name": "Bruno Test Service",
+    "description": "Created by Bruno API tests"
+  }
+}
+
+script:pre-request {
+  const token = bru.getVar("admin_token");
+  if (token) {
+    req.setHeader("Authorization", "Bearer " + token);
+  }
+}
+
+script:post-response {
+  if (res.getStatus() === 200) {
+    const body = res.getBody();
+    bru.setVar("created_service_id", body.data.id);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("should return created service", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.data.name).to.equal('Bruno Test Service');
+    expect(body.data.description).to.equal('Created by Bruno API tests');
+    expect(body.data).to.have.property('id');
+  });
+}
+
+docs {
+  # Create Service
+
+  Tests the POST /services endpoint (admin only).
+
+  **Prerequisites:**
+  - Run login-admin.bru first
+}

--- a/.vscode/bruno-collections/Service/delete-service.bru
+++ b/.vscode/bruno-collections/Service/delete-service.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Delete Service
+  type: http
+  seq: 6
+}
+
+delete {
+  url: {{base_url}}/services/{{created_service_id}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{admin_token}}
+}
+
+script:pre-request {
+  const token = bru.getVar("admin_token");
+  if (token) {
+    req.setHeader("Authorization", "Bearer " + token);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("should confirm deletion", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.data.deleted).to.be.true;
+  });
+}
+
+docs {
+  # Delete Service
+
+  Tests the DELETE /services/:id endpoint (admin only).
+
+  **Prerequisites:**
+  - Run create-service.bru first
+}

--- a/.vscode/bruno-collections/Service/get-service-by-id.bru
+++ b/.vscode/bruno-collections/Service/get-service-by-id.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Get Service By ID
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{base_url}}/services/{{created_service_id}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{admin_token}}
+}
+
+script:pre-request {
+  const token = bru.getVar("admin_token");
+  if (token) {
+    req.setHeader("Authorization", "Bearer " + token);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("should return the correct service", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.data.name).to.equal('Bruno Test Service');
+  });
+}
+
+docs {
+  # Get Service By ID
+
+  Tests the GET /services/:id endpoint.
+
+  **Prerequisites:**
+  - Run create-service.bru first to capture created_service_id
+}

--- a/.vscode/bruno-collections/Service/get-service-not-found.bru
+++ b/.vscode/bruno-collections/Service/get-service-not-found.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Get Service Not Found
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{base_url}}/services/nonexistent-id-12345
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{admin_token}}
+}
+
+script:pre-request {
+  const token = bru.getVar("admin_token");
+  if (token) {
+    req.setHeader("Authorization", "Bearer " + token);
+  }
+}
+
+tests {
+  test("should return 404", function() {
+    expect(res.getStatus()).to.equal(404);
+  });
+
+  test("should have RESOURCE_NOT_FOUND error", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.false;
+    expect(body.error.code).to.equal('RESOURCE_NOT_FOUND');
+  });
+}
+
+docs {
+  # Get Service Not Found
+
+  Verifies that requesting a nonexistent service returns 404.
+
+  **Prerequisites:**
+  - Run login-admin.bru first
+}

--- a/.vscode/bruno-collections/Service/list-services.bru
+++ b/.vscode/bruno-collections/Service/list-services.bru
@@ -1,0 +1,71 @@
+meta {
+  name: List Services
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{base_url}}/services
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{admin_token}}
+}
+
+script:pre-request {
+  const token = bru.getVar("admin_token");
+  if (token) {
+    req.setHeader("Authorization", "Bearer " + token);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("should have standard API response format", function() {
+    const body = res.getBody();
+    expect(body).to.have.property('success');
+    expect(body).to.have.property('data');
+    expect(body).to.have.property('error');
+    expect(body).to.have.property('timestamp');
+  });
+
+  test("should return array of services", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.data).to.be.an('array');
+  });
+
+  test("seeded services should be present", function() {
+    const body = res.getBody();
+    const names = body.data.map(s => s.name);
+    expect(names).to.include('Evening');
+    expect(names).to.include('Breakfast');
+  });
+
+  test("each service should have expected fields", function() {
+    const body = res.getBody();
+    if (body.data.length > 0) {
+      const service = body.data[0];
+      expect(service).to.have.property('id');
+      expect(service).to.have.property('name');
+      expect(service).to.have.property('description');
+      expect(service).to.have.property('createdAt');
+      expect(service).to.have.property('updatedAt');
+    }
+  });
+}
+
+docs {
+  # List Services
+
+  Tests the GET /services endpoint.
+
+  **Prerequisites:**
+  - Run login-admin.bru first
+  - Run `bun run seed:test` to seed default services
+}

--- a/.vscode/bruno-collections/Service/login-admin.bru
+++ b/.vscode/bruno-collections/Service/login-admin.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Login Admin
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{base_url}}/auth/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "admin-test@example.com",
+    "password": "{{test_password}}"
+  }
+}
+
+script:post-response {
+  if (res.getStatus() === 200) {
+    const body = res.getBody();
+    bru.setVar("admin_token", body.data.accessToken);
+  }
+}
+
+tests {
+  test("should return 200 status", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("should be an admin user", function() {
+    const body = res.getBody();
+    expect(body.data.user.role).to.equal('ADMIN');
+  });
+}
+
+docs {
+  # Login Admin
+
+  Logs in as admin to get a token for service API tests.
+
+  **Prerequisites:**
+  - Run `bun run seed:test` to create the admin-test@example.com user
+}

--- a/.vscode/bruno-collections/Service/update-service.bru
+++ b/.vscode/bruno-collections/Service/update-service.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Update Service
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{base_url}}/services/{{created_service_id}}
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{admin_token}}
+}
+
+body:json {
+  {
+    "name": "Updated Test Service",
+    "description": "Updated by Bruno API tests"
+  }
+}
+
+script:pre-request {
+  const token = bru.getVar("admin_token");
+  if (token) {
+    req.setHeader("Authorization", "Bearer " + token);
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("should return updated service", function() {
+    const body = res.getBody();
+    expect(body.success).to.be.true;
+    expect(body.data.name).to.equal('Updated Test Service');
+    expect(body.data.description).to.equal('Updated by Bruno API tests');
+  });
+}
+
+docs {
+  # Update Service
+
+  Tests the PUT /services/:id endpoint (admin only).
+
+  **Prerequisites:**
+  - Run create-service.bru first
+}

--- a/.vscode/bruno-collections/seed-test-users.ts
+++ b/.vscode/bruno-collections/seed-test-users.ts
@@ -14,6 +14,7 @@
  */
 
 import { createUser, getUserByEmail } from "../../webapi/src/modules/auth/service.ts";
+import { createService, getServiceByName } from "../../webapi/src/modules/service/service.ts";
 import { UserRole } from "../../webapi/src/constants/userRole.ts";
 import { closeDb } from "../../webapi/src/database/connection.ts";
 import { getLogger } from "@logtape/logtape";
@@ -97,10 +98,63 @@ async function seedTestUsers() {
   }
 }
 
+// Default services to seed
+const DEFAULT_SERVICES = [
+  { name: "Evening", description: "Evening service shift" },
+  { name: "Breakfast", description: "Breakfast service shift" },
+  { name: "Cooks", description: "Cooking service shift" },
+  { name: "Logistics", description: "Logistics service shift" },
+];
+
+function seedServices() {
+  logger.info("Starting service seeding process");
+
+  let created = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const service of DEFAULT_SERVICES) {
+    try {
+      const existing = getServiceByName(service.name);
+
+      if (existing) {
+        logger.info(`Skipping service ${service.name} - already exists`);
+        skipped++;
+        continue;
+      }
+
+      createService(service);
+      logger.info(`Created service: ${service.name}`);
+      created++;
+    } catch (error) {
+      logger.error(`Failed to create service ${service.name}:`, error);
+      errors++;
+    }
+  }
+
+  console.log("\n=== Service Seeding Summary ===");
+  console.log(`Created: ${created}`);
+  console.log(`Skipped (already exist): ${skipped}`);
+  console.log(`Errors: ${errors}`);
+  console.log(`Total: ${DEFAULT_SERVICES.length}`);
+
+  if (created > 0) {
+    console.log("\n✓ Services ready for Bruno tests");
+  }
+
+  return errors;
+}
+
 // Run the seeding process
 try {
   await seedTestUsers();
+  const serviceErrors = seedServices();
   closeDb();
+
+  if (serviceErrors > 0) {
+    console.error("\n✗ Some services failed to seed. Check logs for details.");
+    process.exit(1);
+  }
 } catch (error) {
   logger.error("Fatal error during seeding:", error);
   console.error("\n✗ Fatal error during seeding:", error);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,8 @@ bun run test         # Run all tests (webapi + ui + e2e)
 bun run test:bruno        # Run all Bruno API tests
 bun run test:bruno:health # Run Bruno health tests
 bun run test:bruno:auth   # Run Bruno auth tests
-bun run test:bruno:user   # Run Bruno user tests
+bun run test:bruno:user      # Run Bruno user tests
+bun run test:bruno:service   # Run Bruno service tests
 bun run seed:test         # Seed test users for Bruno tests
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:bruno:auth": "cd .vscode/bruno-collections && bru run Auth --env local",
     "test:bruno:user": "cd .vscode/bruno-collections && bru run User --env local",
     "test:bruno:admin": "cd .vscode/bruno-collections && bru run Admin --env local",
+    "test:bruno:service": "cd .vscode/bruno-collections && bru run Service --env local",
     "seed:test": "cd webapi && bun run --env-file .env ../.vscode/bruno-collections/seed-test-users.ts"
   },
   "devDependencies": {

--- a/webapi/migrations/006_create_services_table.sql
+++ b/webapi/migrations/006_create_services_table.sql
@@ -1,0 +1,13 @@
+-- Migration: Create services table
+-- Description: Service types that volunteers can subscribe to
+
+CREATE TABLE services (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Index for name lookups
+CREATE INDEX idx_services_name ON services(name);

--- a/webapi/src/app.ts
+++ b/webapi/src/app.ts
@@ -7,6 +7,7 @@ import { jwtPlugin } from "./middleware/jwt.ts";
 import { healthModule } from "./modules/health/index.ts";
 import { authModule } from "./modules/auth/index.ts";
 import { userModule } from "./modules/user/index.ts";
+import { serviceModule } from "./modules/service/index.ts";
 
 /**
  * Main Elysia application instance.
@@ -37,6 +38,9 @@ export function createApp() {
 
         // User endpoints (protected, auth required)
         .use(userModule)
+
+        // Service endpoints (list/get: auth required, CRUD: admin only)
+        .use(serviceModule)
     );
 
   return app;

--- a/webapi/src/constants/dayOfWeek.ts
+++ b/webapi/src/constants/dayOfWeek.ts
@@ -1,0 +1,13 @@
+/**
+ * Day of the week enum.
+ * Numeric values (1–7) are stored in DB columns with CHECK constraints.
+ */
+export enum DayOfWeek {
+  MONDAY = 1,
+  TUESDAY = 2,
+  WEDNESDAY = 3,
+  THURSDAY = 4,
+  FRIDAY = 5,
+  SATURDAY = 6,
+  SUNDAY = 7,
+}

--- a/webapi/src/modules/service/index.ts
+++ b/webapi/src/modules/service/index.ts
@@ -21,6 +21,9 @@ const ServiceResponseSchema = t.Object({
   updatedAt: t.String(),
 });
 
+const IdParamSchema = t.Object({ id: t.String() });
+const SERVICE_TAG = ["Service"] as const;
+
 const CreateServiceRequestSchema = t.Object({
   name: t.String({ minLength: 1, maxLength: 255 }),
   description: t.Optional(t.String({ maxLength: 1000 })),
@@ -44,7 +47,7 @@ export const serviceModule = new Elysia({ prefix: "/services" })
       detail: {
         summary: "List all services",
         description: "Returns all available services",
-        tags: ["Service"],
+        tags: SERVICE_TAG,
       },
       response: {
         200: apiResponseSchema(t.Array(ServiceResponseSchema)),
@@ -62,11 +65,11 @@ export const serviceModule = new Elysia({ prefix: "/services" })
       return success(service);
     },
     {
-      params: t.Object({ id: t.String() }),
+      params: IdParamSchema,
       detail: {
         summary: "Get service by ID",
         description: "Returns a single service by its ID",
-        tags: ["Service"],
+        tags: SERVICE_TAG,
       },
       response: {
         200: apiResponseSchema(ServiceResponseSchema),
@@ -90,7 +93,7 @@ export const serviceModule = new Elysia({ prefix: "/services" })
       body: CreateServiceRequestSchema,
       detail: {
         summary: "Create a service (admin)",
-        tags: ["Service"],
+        tags: SERVICE_TAG,
       },
       response: {
         200: apiResponseSchema(ServiceResponseSchema),
@@ -114,11 +117,11 @@ export const serviceModule = new Elysia({ prefix: "/services" })
       return success(service);
     },
     {
-      params: t.Object({ id: t.String() }),
+      params: IdParamSchema,
       body: UpdateServiceRequestSchema,
       detail: {
         summary: "Update a service (admin)",
-        tags: ["Service"],
+        tags: SERVICE_TAG,
       },
       response: {
         200: apiResponseSchema(ServiceResponseSchema),
@@ -139,10 +142,10 @@ export const serviceModule = new Elysia({ prefix: "/services" })
       return success({ deleted: true });
     },
     {
-      params: t.Object({ id: t.String() }),
+      params: IdParamSchema,
       detail: {
         summary: "Delete a service (admin)",
-        tags: ["Service"],
+        tags: SERVICE_TAG,
       },
       response: {
         200: t.Any(),

--- a/webapi/src/modules/service/index.ts
+++ b/webapi/src/modules/service/index.ts
@@ -1,0 +1,154 @@
+import { Elysia, t } from "elysia";
+import { success, ErrorCode, apiResponseSchema } from "../../utils/response.ts";
+import { ApiError } from "../../middleware/errorHandler.ts";
+import { authGuard } from "../../middleware/authGuard.ts";
+import { roleGuard } from "../../middleware/roleGuard.ts";
+import { UserRole } from "../../constants/userRole.ts";
+import {
+  getAllServices,
+  getServiceById,
+  isServiceNameTaken,
+  createService,
+  updateService,
+  deleteService,
+} from "./service.ts";
+
+const ServiceResponseSchema = t.Object({
+  id: t.String(),
+  name: t.String(),
+  description: t.String(),
+  createdAt: t.String(),
+  updatedAt: t.String(),
+});
+
+const CreateServiceRequestSchema = t.Object({
+  name: t.String({ minLength: 1, maxLength: 255 }),
+  description: t.Optional(t.String({ maxLength: 1000 })),
+});
+
+const UpdateServiceRequestSchema = t.Object({
+  name: t.Optional(t.String({ minLength: 1, maxLength: 255 })),
+  description: t.Optional(t.String({ maxLength: 1000 })),
+});
+
+export const serviceModule = new Elysia({ prefix: "/services" })
+  .use(authGuard)
+  // Authenticated routes (any logged-in user)
+  .get(
+    "/",
+    () => {
+      const services = getAllServices();
+      return success(services);
+    },
+    {
+      detail: {
+        summary: "List all services",
+        description: "Returns all available services",
+        tags: ["Service"],
+      },
+      response: {
+        200: apiResponseSchema(t.Array(ServiceResponseSchema)),
+        401: t.Any(),
+      },
+    }
+  )
+  .get(
+    "/:id",
+    ({ params }) => {
+      const service = getServiceById(params.id);
+      if (!service) {
+        throw new ApiError(ErrorCode.RESOURCE_NOT_FOUND, "Service not found");
+      }
+      return success(service);
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      detail: {
+        summary: "Get service by ID",
+        description: "Returns a single service by its ID",
+        tags: ["Service"],
+      },
+      response: {
+        200: apiResponseSchema(ServiceResponseSchema),
+        401: t.Any(),
+        404: t.Any(),
+      },
+    }
+  )
+  // Admin-only routes
+  .use(roleGuard(UserRole.ADMIN))
+  .post(
+    "/",
+    ({ body }) => {
+      if (isServiceNameTaken(body.name)) {
+        throw new ApiError(ErrorCode.VALIDATION_ERROR, "Service name already exists");
+      }
+      const service = createService(body);
+      return success(service);
+    },
+    {
+      body: CreateServiceRequestSchema,
+      detail: {
+        summary: "Create a service (admin)",
+        tags: ["Service"],
+      },
+      response: {
+        200: apiResponseSchema(ServiceResponseSchema),
+        400: t.Any(),
+        401: t.Any(),
+        403: t.Any(),
+      },
+    }
+  )
+  .put(
+    "/:id",
+    ({ params, body }) => {
+      if (body.name && isServiceNameTaken(body.name, params.id)) {
+        throw new ApiError(ErrorCode.VALIDATION_ERROR, "Service name already exists");
+      }
+
+      const service = updateService(params.id, body);
+      if (!service) {
+        throw new ApiError(ErrorCode.RESOURCE_NOT_FOUND, "Service not found");
+      }
+      return success(service);
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      body: UpdateServiceRequestSchema,
+      detail: {
+        summary: "Update a service (admin)",
+        tags: ["Service"],
+      },
+      response: {
+        200: apiResponseSchema(ServiceResponseSchema),
+        400: t.Any(),
+        401: t.Any(),
+        403: t.Any(),
+        404: t.Any(),
+      },
+    }
+  )
+  .delete(
+    "/:id",
+    ({ params }) => {
+      const deleted = deleteService(params.id);
+      if (!deleted) {
+        throw new ApiError(ErrorCode.RESOURCE_NOT_FOUND, "Service not found");
+      }
+      return success({ deleted: true });
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      detail: {
+        summary: "Delete a service (admin)",
+        tags: ["Service"],
+      },
+      response: {
+        200: t.Any(),
+        401: t.Any(),
+        403: t.Any(),
+        404: t.Any(),
+      },
+    }
+  );

--- a/webapi/src/modules/service/service.ts
+++ b/webapi/src/modules/service/service.ts
@@ -1,0 +1,142 @@
+import { getDb } from "../../database/connection.ts";
+import { generateToken } from "../../utils/crypto.ts";
+
+/**
+ * Service entity as stored in database.
+ */
+export interface Service {
+  id: string;
+  name: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Service response with camelCase keys for API.
+ */
+export interface ServiceResponse {
+  id: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Parameters for creating a service.
+ */
+export interface CreateServiceParams {
+  name: string;
+  description?: string;
+}
+
+/**
+ * Parameters for updating a service.
+ */
+export interface UpdateServiceParams {
+  name?: string;
+  description?: string;
+}
+
+/**
+ * Maps a DB row to a camelCase API response.
+ */
+export function toServiceResponse(service: Service): ServiceResponse {
+  return {
+    id: service.id,
+    name: service.name,
+    description: service.description,
+    createdAt: service.created_at,
+    updatedAt: service.updated_at,
+  };
+}
+
+/**
+ * Retrieves all services.
+ */
+export function getAllServices(): ServiceResponse[] {
+  const db = getDb();
+  const rows = db.prepare("SELECT * FROM services ORDER BY name ASC").all() as Service[];
+  return rows.map(toServiceResponse);
+}
+
+/**
+ * Retrieves a service by ID.
+ */
+export function getServiceById(id: string): ServiceResponse | null {
+  const db = getDb();
+  const row = db.prepare("SELECT * FROM services WHERE id = ?").get(id) as Service | null;
+  return row ? toServiceResponse(row) : null;
+}
+
+/**
+ * Retrieves a service by name.
+ */
+export function getServiceByName(name: string): ServiceResponse | null {
+  const db = getDb();
+  const row = db.prepare("SELECT * FROM services WHERE name = ?").get(name) as Service | null;
+  return row ? toServiceResponse(row) : null;
+}
+
+/**
+ * Checks if a service name is already in use.
+ */
+export function isServiceNameTaken(name: string, excludeId?: string): boolean {
+  const db = getDb();
+  const row = db.prepare("SELECT id FROM services WHERE name = ? AND id != ?").get(name, excludeId ?? "");
+  return row !== null;
+}
+
+/**
+ * Creates a new service.
+ */
+export function createService(params: CreateServiceParams): ServiceResponse {
+  const db = getDb();
+  const id = generateToken(16);
+
+  db.prepare(
+    "INSERT INTO services (id, name, description) VALUES (?, ?, ?)"
+  ).run(id, params.name, params.description ?? "");
+
+  return getServiceById(id)!;
+}
+
+/**
+ * Updates an existing service.
+ */
+export function updateService(id: string, params: UpdateServiceParams): ServiceResponse | null {
+  const db = getDb();
+
+  const updates: string[] = [];
+  const values: string[] = [];
+
+  if (params.name !== undefined) {
+    updates.push("name = ?");
+    values.push(params.name);
+  }
+  if (params.description !== undefined) {
+    updates.push("description = ?");
+    values.push(params.description);
+  }
+
+  if (updates.length === 0) {
+    return getServiceById(id);
+  }
+
+  updates.push("updated_at = datetime('now')");
+  values.push(id);
+
+  db.prepare(`UPDATE services SET ${updates.join(", ")} WHERE id = ?`).run(...values);
+
+  return getServiceById(id);
+}
+
+/**
+ * Deletes a service by ID.
+ */
+export function deleteService(id: string): boolean {
+  const db = getDb();
+  const result = db.prepare("DELETE FROM services WHERE id = ?").run(id);
+  return result.changes > 0;
+}

--- a/webapi/tests/modules/service.test.ts
+++ b/webapi/tests/modules/service.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Set up a temporary database before any app module imports
+const testDir = mkdtempSync(join(tmpdir(), "service-test-"));
+const testDbPath = join(testDir, "test.db");
+process.env.DATABASE_PATH = testDbPath;
+process.env.JWT_SECRET = "test-secret-that-is-at-least-32-characters-long";
+
+// Now import modules that depend on the DB
+import {
+  getAllServices,
+  getServiceById,
+  getServiceByName,
+  isServiceNameTaken,
+  createService,
+  updateService,
+  deleteService,
+} from "../../src/modules/service/service.ts";
+import { getDb } from "../../src/database/connection.ts";
+import { closeDb } from "../../src/database/connection.ts";
+
+beforeAll(() => {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS services (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      description TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("Service - service layer", () => {
+  test("createService creates a service with name and description", () => {
+    const service = createService({ name: "Evening", description: "Evening shift" });
+
+    expect(service).toHaveProperty("id");
+    expect(service.name).toBe("Evening");
+    expect(service.description).toBe("Evening shift");
+    expect(service.createdAt).toBeDefined();
+    expect(service.updatedAt).toBeDefined();
+  });
+
+  test("createService defaults description to empty string", () => {
+    const service = createService({ name: "Breakfast" });
+    expect(service.description).toBe("");
+  });
+
+  test("getAllServices returns all services sorted by name", () => {
+    const services = getAllServices();
+
+    expect(services.length).toBeGreaterThanOrEqual(2);
+    const names = services.map((s) => s.name);
+    expect(names).toEqual([...names].sort());
+  });
+
+  test("getServiceById returns service when found", () => {
+    const created = createService({ name: "Cooks", description: "Cooking shift" });
+    const found = getServiceById(created.id);
+
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("Cooks");
+  });
+
+  test("getServiceById returns null when not found", () => {
+    expect(getServiceById("nonexistent")).toBeNull();
+  });
+
+  test("getServiceByName returns service when found", () => {
+    const found = getServiceByName("Evening");
+
+    expect(found).not.toBeNull();
+    expect(found!.name).toBe("Evening");
+  });
+
+  test("getServiceByName returns null when not found", () => {
+    expect(getServiceByName("Nonexistent")).toBeNull();
+  });
+
+  test("isServiceNameTaken returns true for existing name", () => {
+    expect(isServiceNameTaken("Evening")).toBe(true);
+  });
+
+  test("isServiceNameTaken returns false for unused name", () => {
+    expect(isServiceNameTaken("Unique Name")).toBe(false);
+  });
+
+  test("isServiceNameTaken excludes a specific ID", () => {
+    const service = getServiceByName("Evening")!;
+    expect(isServiceNameTaken("Evening", service.id)).toBe(false);
+  });
+
+  test("updateService updates name", () => {
+    const created = createService({ name: "Logistics", description: "Logistics shift" });
+    const updated = updateService(created.id, { name: "Transport" });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.name).toBe("Transport");
+  });
+
+  test("updateService updates description", () => {
+    const service = getServiceByName("Transport")!;
+    const updated = updateService(service.id, { description: "Transport and logistics" });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.description).toBe("Transport and logistics");
+  });
+
+  test("updateService returns null for nonexistent ID", () => {
+    expect(updateService("nonexistent", { name: "X" })).toBeNull();
+  });
+
+  test("updateService with no changes returns service unchanged", () => {
+    const service = getServiceByName("Transport")!;
+    const updated = updateService(service.id, {});
+
+    expect(updated).not.toBeNull();
+    expect(updated!.name).toBe("Transport");
+  });
+
+  test("deleteService removes the service", () => {
+    const created = createService({ name: "ToDelete" });
+    expect(deleteService(created.id)).toBe(true);
+    expect(getServiceById(created.id)).toBeNull();
+  });
+
+  test("deleteService returns false for nonexistent ID", () => {
+    expect(deleteService("nonexistent")).toBe(false);
+  });
+});

--- a/webapi/tests/modules/service.test.ts
+++ b/webapi/tests/modules/service.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { Database } from "bun:sqlite";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -20,8 +19,7 @@ import {
   updateService,
   deleteService,
 } from "../../src/modules/service/service.ts";
-import { getDb } from "../../src/database/connection.ts";
-import { closeDb } from "../../src/database/connection.ts";
+import { getDb, closeDb } from "../../src/database/connection.ts";
 
 beforeAll(() => {
   const db = getDb();
@@ -62,7 +60,7 @@ describe("Service - service layer", () => {
 
     expect(services.length).toBeGreaterThanOrEqual(2);
     const names = services.map((s) => s.name);
-    expect(names).toEqual([...names].sort());
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
   });
 
   test("getServiceById returns service when found", () => {


### PR DESCRIPTION
## Summary

- Add `DayOfWeek` enum (MONDAY=1 … SUNDAY=7) in `webapi/src/constants/`
- Add migration `006_create_services_table.sql` (id, name, description, created_at, updated_at)
- Add `service` module with routes and service layer for full CRUD
  - `GET /api/v1/services` — list all (auth required)
  - `GET /api/v1/services/:id` — get by ID (auth required)
  - `POST /api/v1/services` — create (admin only)
  - `PUT /api/v1/services/:id` — update (admin only)
  - `DELETE /api/v1/services/:id` — delete (admin only)
- Seed default services (Evening, Breakfast, Cooks, Logistics) via `seed:test`
- Add 16 unit tests for the service layer
- Add 8 Bruno API tests (CRUD + not-found + forbidden)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How has this been tested?

- `bun test` — 27 tests pass (16 new service tests + 11 existing)
- `bun run build` — builds successfully
- `bun run lint` — no lint errors in new files

## Checklist

- [x] My code follows the project's code style
- [x] I have run linting (`bun run lint` / `flutter analyze`)
- [x] I have added or updated tests as appropriate
- [x] All existing tests pass (`bun run test`)
- [x] I have updated documentation if needed
- [x] I have added screenshots for UI changes (if applicable)

## Related issues

Closes #18